### PR TITLE
Add deployment on Gitlab

### DIFF
--- a/content/en/docs/deployment.md
+++ b/content/en/docs/deployment.md
@@ -9,7 +9,7 @@ Sites built using Academic can be deployed in a large variety of ways due to the
 
 If using Netlify, your site will be built automatically, otherwise run the `hugo` command in your terminal to generate your site in the `public/` folder - now it is ready to copy across to your host.
 
-With Academic, you can make a great impression on your visitors with your own [custom domain name]({{< relref "domain.md" >}}). 
+With Academic, you can make a great impression on your visitors with your own [custom domain name]({{< relref "domain.md" >}}).
 
 ## Netlify
 
@@ -22,18 +22,18 @@ Go to [Github](http://www.github.com/) and register for an account if you have n
 [Install Git](https://help.github.com/articles/set-up-git/) if it's not already present on your system. You can check by running `git --version` in your Command Prompt/Terminal app.
 
 Once you have created your Github account and setup Git on your computer, we will create two new repositories (often abbreviated as *repos*) on Github with the following names:
-                                                                    
+
 - `academic-kickstart` or any other name you like - we will save your **content** to this repo
 - `<USERNAME>.github.io` where `<USERNAME>` is your Github username - we will save the **generated website** to this repo
 
 To create the `<USERNAME>.github.io` repository, click the "+" icon in the top right corner and then choose “New Repository”.
- 
-To create the `academic-kickstart` repository, [**fork**](https://github.com/sourcethemes/academic-kickstart#fork-destination-box) the *Academic Kickstart* repository and clone your fork with Git (download it to your computer) by replacing `<USERNAME>` in the following command with your Github username: 
-                                         
+
+To create the `academic-kickstart` repository, [**fork**](https://github.com/sourcethemes/academic-kickstart#fork-destination-box) the *Academic Kickstart* repository and clone your fork with Git (download it to your computer) by replacing `<USERNAME>` in the following command with your Github username:
+
     git clone https://github.com/<USERNAME>/academic-kickstart.git My_Website
     cd My_Website
     git submodule update --init --recursive
-                                             
+
 In your `config.toml` file, set `baseurl = "https://<USERNAME>.github.io/"`, where `<USERNAME>` is your Github username. Stop Hugo if it's running and delete the `public` directory if it exists (by typing `rm -r public/`).
 
 Add your *<USERNAME>.github.io* repository into a submodule in a folder named *public*, replacing *<USERNAME>* with your Github username:
@@ -65,10 +65,67 @@ If you are feeling more adventurous, you can consider automating deployment so t
 
 If you prefer easy automated deployments whenever you make a change to your site, we recommend deploying with Netlify (see above) rather than Github Pages.
 
+## Gitlab pages
+
+[Gitlab](https://www.gitlab.com) pages works similarly to Github pages, but simplifies even more the automatic build process of your website. One key benefit is that it only requires a single repository, which can be private (visitors can not easily see the whole website content).
+
+The process is similar to the one for Github:
+1. Create an account on [Gitlab](http://www.gitlab.com/).
+2. [Install Git](https://help.github.com/articles/set-up-git/) on your system.
+3. Create _one_ repository on Gitlab. Give it a meaningful name, as your website URL will have the following form: `https://<USERNAME>.gitlab.io/<REPOSITORY>`.
+
+On your system, edit the `config.toml` file to set `baseurl = "https://<USERNAME>.github.io/<REPOSITORY>"`, where `<USERNAME>` is your Gitlab username and `<REPOSITORY>` is the name of the repostory. Stop Hugo if it's running and delete the `public` directory if it exists (by typing `rm -r public/`).
+
+Follow the instruction on Gitlab in order to link the existing folder on your system with the Gitlab repository. Add everything and push your initial commit.
+
+Whilst running the above commands you may be prompted for your Gitlab username and password.
+
+### Automating deployment
+
+At this point, only the website content has been published to the Gitlab repository. It has not yet been compiled with Hugo and is not available publicly. The last step is therefore to configure Gitlab to build and publish the website automatically.
+
+To do that, create a file called `.gitlab_ci.yml` in the root of the folder on your computer and add the following content:
+```
+image:
+  name: klakegg/hugo:edge-ext-alpine
+  entrypoint: [""]
+
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
+
+test:
+  script:
+    - hugo
+  except:
+    - master
+
+pages:
+  script:
+    - hugo
+  artifacts:
+    paths:
+      - public
+  only:
+    - master
+```
+
+Then commit this file to Gitlab
+
+    git add .
+    git commit -m "Configure pipeline"
+    git push -u origin master
+
+From now on, each time you commit something to Gitlab, a job will run automatically to recompile your website and publish it to Gitlab pages.
+
+Note that if the repository is private (default), you need to tweak the visibility of the page to allow everyone to see your website. Simply go to your repository on Gitlab > Settings (bottom of the left column) > General > Visibility.
+
+If you prefer easy automated deployments whenever you make a change to your site, we recommend deploying with Netlify (see above) rather than Github Pages.
+
+
 ## Amazon S3
 
 By uploading the contents of your `public` folder to [Amazon S3](https://aws.amazon.com/s3/), your site can be served with dynamic scaling to almost unlimited traffic. This approach has the benefit of being one of the cheapest and most reliable hosting options available as you only pay for what you use.
 
 ## Web host via FTP
 
-Use an FTP client to upload the contents of your `public` folder to a web host. This may be especially convenient for academic students and staff who are provided with university web space. 
+Use an FTP client to upload the contents of your `public` folder to a web host. This may be especially convenient for academic students and staff who are provided with university web space.

--- a/content/en/docs/domain.md
+++ b/content/en/docs/domain.md
@@ -13,4 +13,6 @@ We can highly recommend [Namecheap](https://affiliate.namecheap.com/?affId=10582
 
 **For Github deployments**, you'll need to login to your domain registrar to point your domain to Github, and create a `CNAME` file in the `static` folder of your website, so that Github knows your intentions. For more information, check out the [domains guide by Github](https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/).
 
+**For Gitlab deployments**, you'll need to login to your domain registrar to point your domain to Gitlab, and verify that you indeed own this domain using a TXT record. For more information, check out the [domains guide by Gitlab](https://docs.gitlab.com/ee/user/project/pages/custom_domains_ssl_tls_certification/).
+
 Remember that after you have setup a custom domain, you will need to wait approximately 24-48 hours for the DNS to propagate and then you'll need to update `baseurl` in your `config.toml` to your new URL, regenerate your site (refer to the previous section), and redeploy.


### PR DESCRIPTION
Added details about Gitlab pages deployment using Gitlab CI/CD pipelines.

This is quite important, especially since the shift to Hugo modules. Indeed, the default pipeline proposed by Gitlab can not handle golang modules (as it is based on an image without golang). The proposed PR contains an minimal working example of pipeline configuration which relies on a very widely used image that supports golang modules. 

If for some reason this PR is refused, I think it would be nice to still indicate at least the image to use with Gitlab CI as it is not trivial to find one that works with modules.

_English is not my native language, if some things need to be rephrased, do not hesitate to propose more suitable formulations._